### PR TITLE
Improve lint-staged config

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "**/*.{json}": [
       "prettier --write"
     ],
-    "README.md,articles/*.md,books/**/*.md": [
+    "**/*.md": [
       "prettier --write",
       "markdownlint --fix",
       "textlint --fix"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "prepare": "husky install"
   },
   "lint-staged": {
+    "**/*.{json}": [
+      "prettier --write"
+    ],
     "README.md,articles/*.md,books/**/*.md": [
       "prettier --write",
       "markdownlint --fix",


### PR DESCRIPTION
- `*.json` を prettier に通すように追加
- `*.md` ファイルの指定を簡略化