### PR TITLE
chore: update textlint rules

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -1,16 +1,19 @@
 {
+  "filters": {
+    "comments": true
+  },
   "rules": {
     "preset-ja-technical-writing": {
       "ja-no-mixed-period": {
-        "allowPeriodMarks": [
-          ":"
-        ]
-      }
+        "allowPeriodMarks": [":"]
+      },
+      "no-exclamation-question-mark": false
     },
     "preset-ja-spacing": {
       "ja-space-between-half-and-full-width": {
-        "space": "always",
-        "exceptPunctuation": true
+        "space": [
+          "alphabets"
+        ]
       },
       "ja-space-around-code": {
         "before": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "markdownlint-cli": "^0.33.0",
         "prettier": "^2.8.4",
         "textlint": "^13.3.1",
+        "textlint-filter-rule-comments": "^1.2.2",
         "textlint-rule-preset-ja-spacing": "^2.3.0",
         "textlint-rule-preset-ja-technical-writing": "^7.0.0"
       }
@@ -4200,6 +4201,15 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/textlint-filter-rule-comments": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/textlint-filter-rule-comments/-/textlint-filter-rule-comments-1.2.2.tgz",
+      "integrity": "sha512-AtyxreCPb3Hq/bd6Qd6szY1OGgnW34LOjQXAHzE8NoXbTUudQqALPdRe+hvRsf81rnmGLxBiCUXZbnbpIseFyw==",
+      "dev": true,
+      "peerDependencies": {
+        "textlint": ">=6.8.0"
       }
     },
     "node_modules/textlint-rule-helper": {
@@ -8569,6 +8579,13 @@
           }
         }
       }
+    },
+    "textlint-filter-rule-comments": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/textlint-filter-rule-comments/-/textlint-filter-rule-comments-1.2.2.tgz",
+      "integrity": "sha512-AtyxreCPb3Hq/bd6Qd6szY1OGgnW34LOjQXAHzE8NoXbTUudQqALPdRe+hvRsf81rnmGLxBiCUXZbnbpIseFyw==",
+      "dev": true,
+      "requires": {}
     },
     "textlint-rule-helper": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "markdownlint-cli": "^0.33.0",
     "prettier": "^2.8.4",
     "textlint": "^13.3.1",
+    "textlint-filter-rule-comments": "^1.2.2",
     "textlint-rule-preset-ja-spacing": "^2.3.0",
     "textlint-rule-preset-ja-technical-writing": "^7.0.0"
   }


### PR DESCRIPTION
- enable disable comments
- `ja-space-between-half-and-full-width`
  - alphabets only
  - remove deprecated option(`exceptPunctuation`)
- disable `no-exclamation-question-mark`